### PR TITLE
[FIX] Bug fixed on 'oh_hr_lawsuit_management'

### DIFF
--- a/oh_hr_lawsuit_management/security/ir.model.access.csv
+++ b/oh_hr_lawsuit_management/security/ir.model.access.csv
@@ -1,5 +1,4 @@
 "id","name","model_id:id","group_id:id","perm_read","perm_write","perm_create","perm_unlink"
 "access_hr_lawsuit_manager","hr.access_hr_lawsuit_manager","model_hr_lawsuit","oh_hr_lawsuit_management.lawsuit_group_manager",1,1,1,1
 "access_hr_lawsuit_manager1","hr.access_hr_lawsuit_manager","model_hr_lawsuit",,1,0,0,0
-"access_wizard_lawsuit_manager","hr.access_wizard_lawsuit_manager","model_wizard_lawsuit","oh_hr_lawsuit_management.lawsuit_group_manager",1,1,1,1
 "access_account_invoice","hr.access_account_invoice","account.model_account_invoice","oh_hr_lawsuit_management.lawsuit_group_manager",1,0,0,0


### PR DESCRIPTION
Current behavior before PR:
Throughs an Exception "No matching record found for external id 'model_wizard_lawsuit' in field 'Object'" while installing module "oh_hr_lawsuit_management". Model "wizard.lawsuit" is not available.

Desired behavior after PR is merged:
Removed that access control record from oh_hr_lawsuit_management/security/ir.model.access.csv