### PR TITLE
[FIX] use tracking attribute instead of deprecated track_visibility

### DIFF
--- a/attendance_regularization/models/regularization.py
+++ b/attendance_regularization/models/regularization.py
@@ -20,7 +20,7 @@ class Regular(models.Model):
                                   required=True, help='Employee')
     state_select = fields.Selection([('draft', 'Draft'), ('requested', 'Requested'), ('reject', 'Rejected'),
                                      ('approved', 'Approved')
-                                     ], default='draft', track_visibility='onchange', string='State',
+                                     ], default='draft', tracking=True, string='State',
                                     help='State')
 
     

--- a/hr_custody/models/custody.py
+++ b/hr_custody/models/custody.py
@@ -114,28 +114,28 @@ class HrCustody(models.Model):
     rejected_reason = fields.Text(string='Rejected Reason', copy=False, readonly=1, help="Reason for the rejection")
     renew_rejected_reason = fields.Text(string='Renew Rejected Reason', copy=False, readonly=1,
                                         help="Renew rejected reason")
-    date_request = fields.Date(string='Requested Date', required=True, track_visibility='always', readonly=True,
+    date_request = fields.Date(string='Requested Date', required=True, tracking=True, readonly=True,
                                help="Requested date",
                                states={'draft': [('readonly', False)]}, default=datetime.now().strftime('%Y-%m-%d'))
     employee = fields.Many2one('hr.employee', string='Employee', required=True, readonly=True, help="Employee",
                                default=lambda self: self.env.user.employee_id.id,
                                states={'draft': [('readonly', False)]})
-    purpose = fields.Char(string='Reason', track_visibility='always', required=True, readonly=True, help="Reason",
+    purpose = fields.Char(string='Reason', tracking=True, required=True, readonly=True, help="Reason",
                           states={'draft': [('readonly', False)]})
     custody_name = fields.Many2one('custody.property', string='Property', required=True, readonly=True,
                                    help="Property name",
                                    states={'draft': [('readonly', False)]})
-    return_date = fields.Date(string='Return Date', required=True, track_visibility='always', readonly=True,
+    return_date = fields.Date(string='Return Date', required=True, tracking=True, readonly=True,
                               help="Return date",
                               states={'draft': [('readonly', False)]})
-    renew_date = fields.Date(string='Renewal Return Date', track_visibility='always',
+    renew_date = fields.Date(string='Renewal Return Date', tracking=True,
                              help="Return date for the renewal", readonly=True, copy=False)
     notes = fields.Html(string='Notes')
     renew_return_date = fields.Boolean(default=False, copy=False)
     renew_reject = fields.Boolean(default=False, copy=False)
     state = fields.Selection([('draft', 'Draft'), ('to_approve', 'Waiting For Approval'), ('approved', 'Approved'),
                               ('returned', 'Returned'), ('rejected', 'Refused')], string='Status', default='draft',
-                             track_visibility='always')
+                             tracking=True)
     mail_send = fields.Boolean(string="Mail Send")
 
 

--- a/hr_disciplinary_tracking/models/disciplinary_action.py
+++ b/hr_disciplinary_tracking/models/disciplinary_action.py
@@ -43,7 +43,7 @@ class DisciplinaryAction(models.Model):
         ('action', 'Action Validated'),
         ('cancel', 'Cancelled'),
 
-    ], default='draft', track_visibility='onchange')
+    ], default='draft', tracking=True)
 
     name = fields.Char(string='Reference', required=True, copy=False, readonly=True,
                        default=lambda self: _('New'))

--- a/hr_gratuity_settlement/models/employee_gratuity.py
+++ b/hr_gratuity_settlement/models/employee_gratuity.py
@@ -15,7 +15,7 @@ class EmployeeGratuity(models.Model):
         ('validate', 'Validated'),
         ('approve', 'Approved'),
         ('cancel', 'Cancelled')],
-        default='draft', track_visibility='onchange')
+        default='draft', tracking=True)
     name = fields.Char(string='Reference', required=True, copy=False, readonly=True,
                        default=lambda self: _('New'))
     employee_id = fields.Many2one('hr.resignation', string='Employee', required=True,

--- a/hr_gratuity_settlement/models/hr_gratuity.py
+++ b/hr_gratuity_settlement/models/hr_gratuity.py
@@ -14,7 +14,7 @@ class EmployeeGratuity(models.Model):
         ('submit', 'Submitted'),
         ('approve', 'Approved'),
         ('cancel', 'Cancelled')],
-        default='draft', track_visibility='onchange')
+        default='draft', tracking=True)
     name = fields.Char(string='Reference', required=True, copy=False,
                        readonly=True,
                        default=lambda self: _('New'))

--- a/hr_gratuity_settlement/models/other_settlements.py
+++ b/hr_gratuity_settlement/models/other_settlements.py
@@ -15,7 +15,7 @@ class OtherSettlements(models.Model):
         ('validate', 'Validated'),
         ('approve', 'Approved'),
         ('cancel', 'Cancelled'),
-    ], default='draft', track_visibility='onchange')
+    ], default='draft', tracking=True)
 
     name = fields.Char(string='Reference', required=True, copy=False, readonly=True,
                        default=lambda self: _('New'))

--- a/hr_resignation/models/hr_resignation.py
+++ b/hr_resignation/models/hr_resignation.py
@@ -22,10 +22,10 @@ class HrResignation(models.Model):
                                     help='Department of the employee')
     resign_confirm_date = fields.Date(string="Confirmed Date",
                                       help='Date on which the request is confirmed by the employee.',
-                                      track_visibility="always")
+                                      tracking=True)
     approved_revealing_date = fields.Date(string="Approved Last Day Of Employee",
                                           help='Date on which the request is confirmed by the manager.',
-                                          track_visibility="always")
+                                          tracking=True)
     joined_date = fields.Date(string="Join Date", store=True,
                               help='Joining date of the employee.i.e Start date of the first contract')
 
@@ -35,7 +35,7 @@ class HrResignation(models.Model):
     notice_period = fields.Char(string="Notice Period")
     state = fields.Selection(
         [('draft', 'Draft'), ('confirm', 'Confirm'), ('approved', 'Approved'), ('cancel', 'Rejected')],
-        string='Status', default='draft', track_visibility="always")
+        string='Status', default='draft', tracking=True)
     resignation_type = fields.Selection(selection=RESIGNATION_TYPE, help="Select the type of resignation: normal "
                                                                          "resignation or fired by the company")
     read_only = fields.Boolean(string="check field")

--- a/hr_reward_warning/models/hr_warning.py
+++ b/hr_reward_warning/models/hr_warning.py
@@ -37,7 +37,7 @@ class HrAnnouncementTable(models.Model):
     state = fields.Selection([('draft', 'Draft'), ('to_approve', 'Waiting For Approval'),
                               ('approved', 'Approved'), ('rejected', 'Refused'), ('expired', 'Expired')],
                              string='Status',  default='draft',
-                             track_visibility='always')
+                             tracking=True)
     requested_date = fields.Date(string='Requested Date', default=datetime.now().strftime('%Y-%m-%d'),
                                  help="Create Date of Record")
     attachment_id = fields.Many2many('ir.attachment', 'doc_warning_rel', 'doc_id', 'attach_id4',

--- a/oh_appraisal/models/hr_appraisal_form.py
+++ b/oh_appraisal/models/hr_appraisal_form.py
@@ -64,7 +64,7 @@ class HrAppraisalForm(models.Model):
     tot_comp_survey = fields.Integer(string="Count Answers", compute="_compute_completed_survey")
     tot_sent_survey = fields.Integer(string="Count Sent Questions")
     created_by = fields.Many2one('res.users', string="Created By", default=lambda self: self.env.uid)
-    state = fields.Many2one('hr.appraisal.stages', string='Stage', track_visibility='onchange', index=True,
+    state = fields.Many2one('hr.appraisal.stages', string='Stage', tracking=True, index=True,
                             default=lambda self: self._default_stage_id(),
                             group_expand='_read_group_stage_ids')
     # for coloring the kanban box

--- a/oh_hr_lawsuit_management/models/legal_action.py
+++ b/oh_hr_lawsuit_management/models/legal_action.py
@@ -42,12 +42,12 @@ class HrLawsuit(models.Model):
                                  states={'draft': [('readonly', False)]})
     hearing_date = fields.Date(string='Hearing Date',
                                help='Upcoming hearing date')
-    court_name = fields.Char(string='Court Name', track_visibility='always',
+    court_name = fields.Char(string='Court Name', tracking=True,
                              states={'won': [('readonly', True)]},
                              help='Name of the Court')
-    judge = fields.Char(string='Judge', track_visibility='always', states={'won': [('readonly', True)]},
+    judge = fields.Char(string='Judge', tracking=True, states={'won': [('readonly', True)]},
                         help='Name of the Judge')
-    lawyer = fields.Many2one('res.partner', string='Lawyer', track_visibility='always',
+    lawyer = fields.Many2one('res.partner', string='Lawyer', tracking=True,
                              help='Choose the contact of Layer from the contact list',
                              states={'won': [('readonly', True)]})
     party1 = fields.Many2one('res.company', string='Party 1', required=1, readonly=1,
@@ -69,14 +69,14 @@ class HrLawsuit(models.Model):
                                  help='Choose the partner')
     other_name = fields.Char(string='Name', help='Enter the details of other type')
     party2_name = fields.Char(compute='set_party2', string='Name', store=True)
-    case_details = fields.Html(string='Case Details', copy=False, track_visibility='always',
+    case_details = fields.Html(string='Case Details', copy=False, tracking=True,
                                help='More details of the case')
     state = fields.Selection([('draft', 'Draft'),
                               ('running', 'Running'),
                               ('cancel', 'Cancelled'),
                               ('fail', 'Failed'),
                               ('won', 'Won')], string='Status',
-                             default='draft', track_visibility='always', copy=False,
+                             default='draft', tracking=True, copy=False,
                              help='Status')
 
 

--- a/ohrms_holidays_approval/models/leave_request.py
+++ b/ohrms_holidays_approval/models/leave_request.py
@@ -9,7 +9,7 @@ class HrLeave(models.Model):
     leave_approvals = fields.One2many('leave.validation.status',
                                       'holiday_status',
                                       string='Leave Validators',
-                                      track_visibility='always',
+                                      tracking=True,
                                       help="Leave approvals")
     multi_level_validation = fields.Boolean(
         string='Multiple Level Approval',
@@ -226,7 +226,7 @@ class LeaveValidationStatus(models.Model):
                                        domain="[('share','=',False)]")
     validation_status = fields.Boolean(string='Approve Status', readonly=True,
                                        default=False,
-                                       track_visibility='always', help="Status")
+                                       tracking=True, help="Status")
     leave_comments = fields.Text(string='Comments', help="Comments")
 
     @api.onchange('validating_users')

--- a/ohrms_loan/models/hr_loan.py
+++ b/ohrms_loan/models/hr_loan.py
@@ -62,7 +62,7 @@ class HrLoan(models.Model):
         ('approve', 'Approved'),
         ('refuse', 'Refused'),
         ('cancel', 'Canceled'),
-    ], string="State", default='draft', track_visibility='onchange', copy=False, )
+    ], string="State", default='draft', tracking=True, copy=False, )
 
     @api.model
     def create(self, values):

--- a/ohrms_loan_accounting/models/hr_loan_acc.py
+++ b/ohrms_loan_accounting/models/hr_loan_acc.py
@@ -18,7 +18,7 @@ class HrLoanAcc(models.Model):
         ('approve', 'Approved'),
         ('refuse', 'Refused'),
         ('cancel', 'Canceled'),
-    ], string="State", default='draft', track_visibility='onchange', copy=False, )
+    ], string="State", default='draft', tracking=True, copy=False, )
 
     def action_approve(self):
         """This create account move for request.

--- a/ohrms_salary_advance/models/salary_advance.py
+++ b/ohrms_salary_advance/models/salary_advance.py
@@ -28,7 +28,7 @@ class SalaryAdvancePayment(models.Model):
                               ('waiting_approval', 'Waiting Approval'),
                               ('approve', 'Approved'),
                               ('cancel', 'Cancelled'),
-                              ('reject', 'Rejected')], string='Status', default='draft', track_visibility='onchange')
+                              ('reject', 'Rejected')], string='Status', default='draft', tracking=True)
     debit = fields.Many2one('account.account', string='Debit Account')
     credit = fields.Many2one('account.account', string='Credit Account')
     journal = fields.Many2one('account.journal', string='Journal')

--- a/ohrms_service_request/models/service.py
+++ b/ohrms_service_request/models/service.py
@@ -22,7 +22,7 @@ class Service(models.Model):
                               ('assign', 'Assigned'),
                               ('check', 'Checked'),
                               ('reject', 'Rejected'),
-                              ('approved', 'Approved')], default='draft', track_visibility='onchange', help="State")
+                              ('approved', 'Approved')], default='draft', tracking=True, help="State")
     service_executer = fields.Many2one('hr.employee', string='Service Executer', help="Service executer")
     read_only = fields.Boolean(string="check field", compute='get_user')
     tester = fields.One2many('service.execute', 'test', string='tester', help="Tester")
@@ -111,7 +111,7 @@ class Executer(models.Model):
     execute_date = fields.Datetime(string="Date Of Reporting", help="Date of reporting")
     state_execute = fields.Selection([('draft', 'Draft'), ('requested', 'Requested'), ('assign', 'Assigned')
                                  , ('check', 'Checked'), ('reject', 'Rejected'),
-                              ('approved', 'Approved')], track_visibility='onchange')
+                              ('approved', 'Approved')], tracking=True)
     test = fields.Many2one('service.request', string='test', help="Test")
     notes = fields.Text(string="Internal notes", help="Internal Notes")
     executer_product = fields.Char(string='Service Item', help="service item")

--- a/saudi_gosi/models/gosi.py
+++ b/saudi_gosi/models/gosi.py
@@ -11,10 +11,10 @@ class Saudi(models.Model):
     department = fields.Char(string="Department", required=True, help="Department")
     position = fields.Char(string='Job Position', required=True, help="Job Position")
     nationality = fields.Char(string='Nationality', required=True, help="Nationality")
-    type_gosi = fields.Char(string='Type', required=True, track_visibility='onchange', help="Gosi Type")
+    type_gosi = fields.Char(string='Type', required=True, tracking=True, help="Gosi Type")
     dob = fields.Char(string='Date Of Birth', required=True, help="Date Of Birth")
-    gos_numb = fields.Char(string='GOSI Number', required=True, track_visibility='onchange', help="Gosi number")
-    issued_dat = fields.Char(string='Issued Date', required=True, track_visibility='onchange', help="Issued date")
+    gos_numb = fields.Char(string='GOSI Number', required=True, tracking=True, help="Gosi number")
+    issued_dat = fields.Char(string='Issued Date', required=True, tracking=True, help="Issued date")
     name = fields.Char(string='Reference', required=True, copy=False, readonly=True,
                        default=lambda self: _('New'))
 


### PR DESCRIPTION
Changes:
`track_visibility='always'` -> `tracking=True`
`track_visibility='onchange'` -> `tracking=True`

In modules:
```
  attendance_regularization
  hr_custody
  hr_disciplinary_tracking
  hr_gratuity_settlement
  hr_resignation
  hr_reward_warning
  oh_appraisal
  oh_hr_lawsuit_management
  ohrms_holidays_approval
  ohrms_loan
  ohrms_loan_accounting
  ohrms_salary_advance
  ohrms_service_request
  saudi_gosi
```
Avoid getting 
<pre>WARNING database odoo.fields: Field hr.resignation.resign_confirm_date: unknown parameter 'track_visibility', if this is an actual parameter you may want to override the method _valid_field_parameter on the relevant model in order to allow it</pre>