### PR TITLE
[15.0] Enable Contract level analytic account

### DIFF
--- a/hr_payroll_account_community/models/hr_payroll_account.py
+++ b/hr_payroll_account_community/models/hr_payroll_account.py
@@ -76,7 +76,7 @@ class HrPayslip(models.Model):
                     continue
                 debit_account_id = line.salary_rule_id.account_debit.id
                 credit_account_id = line.salary_rule_id.account_credit.id
-
+                cost_center = slip.contract_id.analytic_account_id.id or line.salary_rule_id.analytic_account_id.id
                 if debit_account_id:
                     debit_line = (0, 0, {
                         'name': line.name,
@@ -86,7 +86,7 @@ class HrPayslip(models.Model):
                         'date': date,
                         'debit': amount > 0.0 and amount or 0.0,
                         'credit': amount < 0.0 and -amount or 0.0,
-                        'analytic_account_id': line.salary_rule_id.analytic_account_id.id,
+                        'analytic_account_id': cost_center,
                         'tax_line_id': line.salary_rule_id.account_tax_id.id,
                     })
                     line_ids.append(debit_line)
@@ -100,7 +100,7 @@ class HrPayslip(models.Model):
                         'date': date,
                         'debit': amount < 0.0 and -amount or 0.0,
                         'credit': amount > 0.0 and amount or 0.0,
-                        'analytic_account_id': line.salary_rule_id.analytic_account_id.id,
+                        'analytic_account_id': cost_center,
                         'tax_line_id': line.salary_rule_id.account_tax_id.id,
                     })
                     line_ids.append(credit_line)


### PR DESCRIPTION
This will allow to define analytic account at contract level, having priority over salary rules' analytic account.
If contract does not have an analytic account defined, it will fall back to original analytic account from salary rule.

