### PR TITLE
Fix current company from env in multi company

### DIFF
--- a/hr_employee_transfer/models/hr_contract.py
+++ b/hr_employee_transfer/models/hr_contract.py
@@ -4,7 +4,7 @@ from odoo import models, fields, api
 class HrContract(models.Model):
     _inherit = 'hr.contract'
 
-    company_id = fields.Many2one('res.company', 'Company', default=lambda self: self.env.user.company_id)
+    company_id = fields.Many2one('res.company', 'Company', default=lambda self: self.env.company)
     from_transfer = fields.Boolean(string='Transferred', default=False)
     emp_transfer = fields.Many2one('employee.transfer', string='Transferred Employee', help="Transferred employee")
 


### PR DESCRIPTION
self.env.user_id.company_id returns the default company linked to current user, not the "Actual" company the user is working on. It is even possible that "default" company is not selected, triggering a security rule error. Correct use is self.env.company, that will provide the actual company the user has active.