### PR TITLE
Fix current company from env in multi company

### DIFF
--- a/hr_multi_company/models/hr_multi_company.py
+++ b/hr_multi_company/models/hr_multi_company.py
@@ -27,25 +27,25 @@ class HrAttendanceMultiCompany(models.Model):
     _inherit = 'hr.attendance'
 
     company_id = fields.Many2one('res.company', 'Company', copy=False, readonly=True, help="Company",
-                                 default=lambda self: self.env.user.company_id)
+                                 default=lambda self: self.env.company)
 
 
 class HrLeaveMultiCompany(models.Model):
     _inherit = 'hr.leave'
 
     company_id = fields.Many2one('res.company', 'Company', copy=False, readonly=True, help="Company",
-                                 default=lambda self: self.env.user.company_id)
+                                 default=lambda self: self.env.company)
 
 
 class HrPayslipMultiCompany(models.Model):
     _inherit = 'hr.payslip.run'
 
     company_id = fields.Many2one('res.company', 'Company', copy=False, readonly=True, help="Company",
-                                 default=lambda self: self.env.user.company_id)
+                                 default=lambda self: self.env.company)
 
 
 class HrSalaryCategoryMultiCompany(models.Model):
     _inherit = 'hr.salary.rule.category'
 
     company_id = fields.Many2one('res.company', 'Company', copy=False, readonly=True, help="Comapny",
-                                 default=lambda self: self.env.user.company_id)
+                                 default=lambda self: self.env.company)


### PR DESCRIPTION
self.env.user_id.company_id returns the default company linked to current user, not the "Actual" company the user is working on. It is even possible that "default" company is not selected, triggering a security rule error. 
Correct use is self.env.company, that will provide the actual company the user has active.