### PR TITLE
Fix current company from env in multi company

### DIFF
--- a/hr_multi_company/models/hr_salary_rule_category.py
+++ b/hr_multi_company/models/hr_salary_rule_category.py
@@ -30,4 +30,4 @@ class HrSalaryRuleCategory(models.Model):
     company_id = fields.Many2one(comodel_name='res.company', string='Company',
                                  copy=False, readonly=True,
                                  help="Company of the category.",
-                                 default=lambda self: self.env.user.company_id)
+                                 default=lambda self: self.env.company)


### PR DESCRIPTION
self.env.user_id.company_id returns the default company linked to current user, not the "Actual" company the user is working on. It is even possible that "default" company is not selected, triggering a security rule error. Correct use is self.env.company, that will provide the actual company the user has active.