### PR TITLE
Fix current company from env in multi company

### DIFF
--- a/hr_multi_company/models/hr_leave.py
+++ b/hr_multi_company/models/hr_leave.py
@@ -30,4 +30,4 @@ class HrLeave(models.Model):
     company_id = fields.Many2one(
         comodel_name='res.company', string='Company', copy=False, readonly=True,
         help="Company of the leave request.",
-        default=lambda self: self.env.user.company_id.id)
+        default=lambda self: self.env.company.id)


### PR DESCRIPTION
self.env.user_id.company_id returns the default company linked to current user, not the "Actual" company the user is working on. It is even possible that "default" company is not selected, triggering a security rule error. Correct use is self.env.company, that will provide the actual company the user has active.