### PR TITLE
Changed the line 40 from:

### DIFF
--- a/hr_payroll_community/wizard/hr_payroll_payslips_by_employees.py
+++ b/hr_payroll_community/wizard/hr_payroll_payslips_by_employees.py
@@ -36,6 +36,6 @@ class HrPayslipEmployees(models.TransientModel):
                     'credit_note': run_data.get('credit_note'),
                     'company_id': employee.company_id.id,
                 }
-            payslips += self.env['hr.payslip'].create(res)
+            payslips = self.env['hr.payslip'].create(res)
             payslips.compute_sheet()
         return {'type': 'ir.actions.act_window_close'}


### PR DESCRIPTION
payslip += self.env['hr.payslip'].create(res)
payslip = self.env['hr.payslip'].create(res)

The payslip generation takes too long because when processing payslips, it starts all over again on every iteration. Removing the compound addition solves this.